### PR TITLE
feat: add next/3 and previous/3 to TimeSlot

### DIFF
--- a/lib/open_hours/time_slot.ex
+++ b/lib/open_hours/time_slot.ex
@@ -47,12 +47,85 @@ defmodule OpenHours.TimeSlot do
     |> Enum.flat_map(&time_slots_for(schedule, starts_at, ends_at, &1))
   end
 
-  defp time_slots_for(
-         %Schedule{} = schedule,
-         %DateTime{} = _starts_at,
-         %DateTime{} = _ends_at,
-         %Date{} = day
-       ) do
+  @max_search_days 366
+
+  @doc """
+  Returns the next time slots from the given DateTime, looking forward in the schedule.
+
+  ## Options
+
+    * `:limit` - number of slots to return (default: `1`)
+    * `:inclusive` - if `true`, includes the slot containing the given DateTime (default: `true`)
+
+  Returns a list of `%TimeSlot{}` structs ordered chronologically.
+  """
+  @spec next(Schedule.t(), DateTime.t(), keyword()) :: [t()]
+  def next(schedule, at, opts \\ [])
+
+  def next(%Schedule{time_zone: schedule_tz} = schedule, %DateTime{time_zone: dt_tz} = at, opts)
+      when schedule_tz != dt_tz do
+    {:ok, shifted} = DateTime.shift_zone(at, schedule_tz, Tzdata.TimeZoneDatabase)
+    next(schedule, shifted, opts)
+  end
+
+  def next(%Schedule{} = schedule, %DateTime{} = at, opts) do
+    limit = Keyword.get(opts, :limit, 1)
+    inclusive = Keyword.get(opts, :inclusive, true)
+
+    at
+    |> DateTime.to_date()
+    |> Date.range(Date.add(DateTime.to_date(at), @max_search_days))
+    |> Stream.reject(&Enum.member?(schedule.holidays, &1))
+    |> Stream.flat_map(&time_slots_for_day(schedule, &1))
+    |> Stream.filter(fn slot ->
+      if inclusive do
+        DateTime.compare(slot.ends_at, at) == :gt
+      else
+        DateTime.compare(slot.starts_at, at) == :gt
+      end
+    end)
+    |> Enum.take(limit)
+  end
+
+  @doc """
+  Returns the previous time slots from the given DateTime, looking backward in the schedule.
+
+  ## Options
+
+    * `:limit` - number of slots to return (default: `1`)
+    * `:inclusive` - if `true`, includes the slot containing the given DateTime (default: `true`)
+
+  Returns a list of `%TimeSlot{}` structs ordered from most recent to least recent.
+  """
+  @spec previous(Schedule.t(), DateTime.t(), keyword()) :: [t()]
+  def previous(schedule, at, opts \\ [])
+
+  def previous(%Schedule{time_zone: schedule_tz} = schedule, %DateTime{time_zone: dt_tz} = at, opts)
+      when schedule_tz != dt_tz do
+    {:ok, shifted} = DateTime.shift_zone(at, schedule_tz, Tzdata.TimeZoneDatabase)
+    previous(schedule, shifted, opts)
+  end
+
+  def previous(%Schedule{} = schedule, %DateTime{} = at, opts) do
+    limit = Keyword.get(opts, :limit, 1)
+    inclusive = Keyword.get(opts, :inclusive, true)
+
+    at
+    |> DateTime.to_date()
+    |> Date.range(Date.add(DateTime.to_date(at), -@max_search_days), -1)
+    |> Stream.reject(&Enum.member?(schedule.holidays, &1))
+    |> Stream.flat_map(&(schedule |> time_slots_for_day(&1) |> Enum.reverse()))
+    |> Stream.filter(fn slot ->
+      if inclusive do
+        DateTime.compare(slot.starts_at, at) == :lt
+      else
+        DateTime.compare(slot.ends_at, at) == :lt
+      end
+    end)
+    |> Enum.take(limit)
+  end
+
+  defp time_slots_for_day(%Schedule{} = schedule, %Date{} = day) do
     schedule
     |> get_intervals_for(day)
     |> Enum.map(fn {interval_start, interval_end} ->
@@ -71,6 +144,15 @@ defmodule OpenHours.TimeSlot do
           )
       }
     end)
+  end
+
+  defp time_slots_for(
+         %Schedule{} = schedule,
+         %DateTime{} = _starts_at,
+         %DateTime{} = _ends_at,
+         %Date{} = day
+       ) do
+    time_slots_for_day(schedule, day)
   end
 
   defp build_date_time(%Date{} = day, time) do

--- a/lib/open_hours/time_slot.ex
+++ b/lib/open_hours/time_slot.ex
@@ -53,7 +53,8 @@ defmodule OpenHours.TimeSlot do
   ## Options
 
     * `:limit` - number of slots to return (default: `1`)
-    * `:inclusive` - if `true`, includes the slot containing the given DateTime (default: `true`)
+    * `:include_overlap` - if `true`, includes the slot containing the given DateTime
+      (default: `true`)
 
   Returns a list of `%TimeSlot{}` structs ordered chronologically.
   """
@@ -73,12 +74,12 @@ defmodule OpenHours.TimeSlot do
 
   def next(%Schedule{} = schedule, %DateTime{} = at, opts) do
     limit = Keyword.get(opts, :limit, 1)
-    inclusive = Keyword.get(opts, :inclusive, true)
+    include_overlap = Keyword.get(opts, :include_overlap, true)
 
     schedule
     |> stream_forward(DateTime.to_date(at))
     |> Stream.filter(fn slot ->
-      if inclusive do
+      if include_overlap do
         DateTime.compare(slot.ends_at, at) == :gt
       else
         DateTime.compare(slot.starts_at, at) == :gt
@@ -93,7 +94,8 @@ defmodule OpenHours.TimeSlot do
   ## Options
 
     * `:limit` - number of slots to return (default: `1`)
-    * `:inclusive` - if `true`, includes the slot containing the given DateTime (default: `true`)
+    * `:include_overlap` - if `true`, includes the slot containing the given DateTime
+      (default: `true`)
 
   Returns a list of `%TimeSlot{}` structs ordered from most recent to least recent.
   """
@@ -113,12 +115,12 @@ defmodule OpenHours.TimeSlot do
 
   def previous(%Schedule{} = schedule, %DateTime{} = at, opts) do
     limit = Keyword.get(opts, :limit, 1)
-    inclusive = Keyword.get(opts, :inclusive, true)
+    include_overlap = Keyword.get(opts, :include_overlap, true)
 
     schedule
     |> stream_backward(DateTime.to_date(at))
     |> Stream.filter(fn slot ->
-      if inclusive do
+      if include_overlap do
         DateTime.compare(slot.starts_at, at) == :lt
       else
         DateTime.compare(slot.ends_at, at) == :lt

--- a/lib/open_hours/time_slot.ex
+++ b/lib/open_hours/time_slot.ex
@@ -47,8 +47,6 @@ defmodule OpenHours.TimeSlot do
     |> Enum.flat_map(&time_slots_for(schedule, starts_at, ends_at, &1))
   end
 
-  @max_search_days 366
-
   @doc """
   Returns the next time slots from the given DateTime, looking forward in the schedule.
 
@@ -68,15 +66,17 @@ defmodule OpenHours.TimeSlot do
     next(schedule, shifted, opts)
   end
 
+  def next(%Schedule{} = schedule, %DateTime{} = _at, _opts)
+      when schedule.hours == %{} and schedule.shifts == [] do
+    []
+  end
+
   def next(%Schedule{} = schedule, %DateTime{} = at, opts) do
     limit = Keyword.get(opts, :limit, 1)
     inclusive = Keyword.get(opts, :inclusive, true)
 
-    at
-    |> DateTime.to_date()
-    |> Date.range(Date.add(DateTime.to_date(at), @max_search_days))
-    |> Stream.reject(&Enum.member?(schedule.holidays, &1))
-    |> Stream.flat_map(&time_slots_for_day(schedule, &1))
+    schedule
+    |> stream_forward(DateTime.to_date(at))
     |> Stream.filter(fn slot ->
       if inclusive do
         DateTime.compare(slot.ends_at, at) == :gt
@@ -106,15 +106,17 @@ defmodule OpenHours.TimeSlot do
     previous(schedule, shifted, opts)
   end
 
+  def previous(%Schedule{} = schedule, %DateTime{} = _at, _opts)
+      when schedule.hours == %{} and schedule.shifts == [] do
+    []
+  end
+
   def previous(%Schedule{} = schedule, %DateTime{} = at, opts) do
     limit = Keyword.get(opts, :limit, 1)
     inclusive = Keyword.get(opts, :inclusive, true)
 
-    at
-    |> DateTime.to_date()
-    |> Date.range(Date.add(DateTime.to_date(at), -@max_search_days), -1)
-    |> Stream.reject(&Enum.member?(schedule.holidays, &1))
-    |> Stream.flat_map(&(schedule |> time_slots_for_day(&1) |> Enum.reverse()))
+    schedule
+    |> stream_backward(DateTime.to_date(at))
     |> Stream.filter(fn slot ->
       if inclusive do
         DateTime.compare(slot.starts_at, at) == :lt
@@ -123,6 +125,20 @@ defmodule OpenHours.TimeSlot do
       end
     end)
     |> Enum.take(limit)
+  end
+
+  defp stream_forward(%Schedule{} = schedule, %Date{} = from) do
+    from
+    |> Stream.iterate(&Date.add(&1, 1))
+    |> Stream.reject(&Enum.member?(schedule.holidays, &1))
+    |> Stream.flat_map(&time_slots_for_day(schedule, &1))
+  end
+
+  defp stream_backward(%Schedule{} = schedule, %Date{} = from) do
+    from
+    |> Stream.iterate(&Date.add(&1, -1))
+    |> Stream.reject(&Enum.member?(schedule.holidays, &1))
+    |> Stream.flat_map(&(schedule |> time_slots_for_day(&1) |> Enum.reverse()))
   end
 
   defp time_slots_for_day(%Schedule{} = schedule, %Date{} = day) do

--- a/lib/open_hours/time_slot.ex
+++ b/lib/open_hours/time_slot.ex
@@ -44,7 +44,7 @@ defmodule OpenHours.TimeSlot do
     |> DateTime.to_date()
     |> Date.range(DateTime.to_date(ends_at))
     |> Enum.reject(&Enum.member?(schedule.holidays, &1))
-    |> Enum.flat_map(&time_slots_for(schedule, starts_at, ends_at, &1))
+    |> Enum.flat_map(&time_slots_for_day(schedule, &1))
   end
 
   @doc """
@@ -146,33 +146,10 @@ defmodule OpenHours.TimeSlot do
     |> get_intervals_for(day)
     |> Enum.map(fn {interval_start, interval_end} ->
       %TimeSlot{
-        starts_at:
-          DateTime.from_naive!(
-            build_date_time(day, interval_start),
-            schedule.time_zone,
-            Tzdata.TimeZoneDatabase
-          ),
-        ends_at:
-          DateTime.from_naive!(
-            build_date_time(day, interval_end),
-            schedule.time_zone,
-            Tzdata.TimeZoneDatabase
-          )
+        starts_at: DateTime.new!(day, interval_start, schedule.time_zone, Tzdata.TimeZoneDatabase),
+        ends_at: DateTime.new!(day, interval_end, schedule.time_zone, Tzdata.TimeZoneDatabase)
       }
     end)
-  end
-
-  defp time_slots_for(
-         %Schedule{} = schedule,
-         %DateTime{} = _starts_at,
-         %DateTime{} = _ends_at,
-         %Date{} = day
-       ) do
-    time_slots_for_day(schedule, day)
-  end
-
-  defp build_date_time(%Date{} = day, time) do
-    with {:ok, date} <- NaiveDateTime.new(day, time), do: date
   end
 
   defp get_intervals_for(

--- a/test/open_hours/time_slot_test.exs
+++ b/test/open_hours/time_slot_test.exs
@@ -77,6 +77,248 @@ defmodule OpenHours.TimeSlotTest do
     end
   end
 
+  @schedule %Schedule{
+    hours: %{
+      mon: [{~T[09:00:00], ~T[14:00:00]}, {~T[15:00:00], ~T[20:00:00]}],
+      tue: [{~T[09:00:00], ~T[14:00:00]}, {~T[15:00:00], ~T[20:00:00]}],
+      wed: [{~T[09:00:00], ~T[14:00:00]}, {~T[15:00:00], ~T[20:00:00]}],
+      thu: [{~T[09:00:00], ~T[14:00:00]}, {~T[15:00:00], ~T[20:00:00]}],
+      fri: [{~T[09:00:00], ~T[14:00:00]}, {~T[15:00:00], ~T[20:00:00]}]
+    },
+    holidays: [~D[2019-01-15]],
+    shifts: [{~D[2019-01-18], [{~T[10:00:00], ~T[14:00:00]}]}],
+    breaks: [{~D[2019-01-16], [{~T[17:00:00], ~T[20:00:00]}]}],
+    time_zone: "Europe/Madrid"
+  }
+
+  describe "next/3" do
+    test "returns the containing slot when datetime is within business hours" do
+      # Wednesday 2019-01-16 10:30 is within 09:00-14:00
+      dt = build_dt(~N[2019-01-16 10:30:00])
+
+      assert TimeSlot.next(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 14:00:00])
+               }
+             ]
+    end
+
+    test "returns the next slot when datetime is outside business hours" do
+      # Wednesday 2019-01-16 14:30 is between the two slots
+      dt = build_dt(~N[2019-01-16 14:30:00])
+
+      assert TimeSlot.next(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 17:00:00])
+               }
+             ]
+    end
+
+    test "returns the next day's first slot when past all slots for the day" do
+      # Wednesday 2019-01-16 21:00 is after all slots
+      dt = build_dt(~N[2019-01-16 21:00:00])
+
+      assert TimeSlot.next(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-17 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-17 14:00:00])
+               }
+             ]
+    end
+
+    test "skips holidays" do
+      # Monday 2019-01-14 21:00 — next day (Tuesday) is a holiday, should skip to Wednesday
+      dt = build_dt(~N[2019-01-14 21:00:00])
+
+      assert TimeSlot.next(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 14:00:00])
+               }
+             ]
+    end
+
+    test "respects shifts" do
+      # Friday 2019-01-18 has a shift: 10:00-14:00 instead of regular hours
+      dt = build_dt(~N[2019-01-18 08:00:00])
+
+      assert TimeSlot.next(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-18 10:00:00]),
+                 ends_at: build_dt(~N[2019-01-18 14:00:00])
+               }
+             ]
+    end
+
+    test "respects breaks" do
+      # Wednesday 2019-01-16 has a break 17:00-20:00, so second slot is 15:00-17:00
+      dt = build_dt(~N[2019-01-16 16:00:00])
+
+      assert TimeSlot.next(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 17:00:00])
+               }
+             ]
+    end
+
+    test "returns multiple slots with limit option" do
+      dt = build_dt(~N[2019-01-16 10:30:00])
+
+      result = TimeSlot.next(@schedule, dt, limit: 3)
+
+      assert result == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 14:00:00])
+               },
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 17:00:00])
+               },
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-17 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-17 14:00:00])
+               }
+             ]
+    end
+
+    test "excludes containing slot with inclusive: false" do
+      # Wednesday 2019-01-16 10:30 is within 09:00-14:00, but we want the next one
+      dt = build_dt(~N[2019-01-16 10:30:00])
+
+      assert TimeSlot.next(@schedule, dt, inclusive: false) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 17:00:00])
+               }
+             ]
+    end
+
+    test "inclusive: false has no effect when outside business hours" do
+      dt = build_dt(~N[2019-01-16 14:30:00])
+
+      assert TimeSlot.next(@schedule, dt, inclusive: false) ==
+               TimeSlot.next(@schedule, dt)
+    end
+
+    test "skips weekends" do
+      # Friday 2019-01-18 after the shift ends — no Sat/Sun hours, should go to Monday
+      dt = build_dt(~N[2019-01-18 15:00:00])
+
+      assert TimeSlot.next(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-21 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-21 14:00:00])
+               }
+             ]
+    end
+
+    test "returns empty list for an empty schedule" do
+      empty = %Schedule{time_zone: "Europe/Madrid"}
+      dt = build_dt(~N[2019-01-16 10:00:00])
+
+      assert TimeSlot.next(empty, dt) == []
+    end
+  end
+
+  describe "previous/3" do
+    test "returns the containing slot when datetime is within business hours" do
+      dt = build_dt(~N[2019-01-16 10:30:00])
+
+      assert TimeSlot.previous(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 14:00:00])
+               }
+             ]
+    end
+
+    test "returns the previous slot when datetime is outside business hours" do
+      # Wednesday 2019-01-16 14:30 is between slots
+      dt = build_dt(~N[2019-01-16 14:30:00])
+
+      assert TimeSlot.previous(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 14:00:00])
+               }
+             ]
+    end
+
+    test "returns the previous day's last slot when before all slots for the day" do
+      # Wednesday 2019-01-16 07:00 — should return Monday's last slot (Tue is holiday)
+      dt = build_dt(~N[2019-01-16 07:00:00])
+
+      assert TimeSlot.previous(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-14 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-14 20:00:00])
+               }
+             ]
+    end
+
+    test "skips holidays" do
+      # Wednesday 2019-01-16 07:00 — Tuesday is a holiday, should return Monday's last slot
+      dt = build_dt(~N[2019-01-16 07:00:00])
+
+      assert TimeSlot.previous(@schedule, dt) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-14 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-14 20:00:00])
+               }
+             ]
+    end
+
+    test "returns multiple slots with limit option" do
+      dt = build_dt(~N[2019-01-17 10:30:00])
+
+      result = TimeSlot.previous(@schedule, dt, limit: 3)
+
+      assert result == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-17 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-17 14:00:00])
+               },
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 17:00:00])
+               },
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 14:00:00])
+               }
+             ]
+    end
+
+    test "excludes containing slot with inclusive: false" do
+      dt = build_dt(~N[2019-01-16 10:30:00])
+
+      assert TimeSlot.previous(@schedule, dt, inclusive: false) == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-14 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-14 20:00:00])
+               }
+             ]
+    end
+
+    test "inclusive: false has no effect when outside business hours" do
+      dt = build_dt(~N[2019-01-16 14:30:00])
+
+      assert TimeSlot.previous(@schedule, dt, inclusive: false) ==
+               TimeSlot.previous(@schedule, dt)
+    end
+
+    test "returns empty list for an empty schedule" do
+      empty = %Schedule{time_zone: "Europe/Madrid"}
+      dt = build_dt(~N[2019-01-16 10:00:00])
+
+      assert TimeSlot.previous(empty, dt) == []
+    end
+  end
+
   defp build_dt(naive_datetime) do
     DateTime.from_naive!(naive_datetime, "Europe/Madrid", Tzdata.TimeZoneDatabase)
   end

--- a/test/open_hours/time_slot_test.exs
+++ b/test/open_hours/time_slot_test.exs
@@ -185,11 +185,11 @@ defmodule OpenHours.TimeSlotTest do
              ]
     end
 
-    test "excludes containing slot with inclusive: false" do
+    test "excludes containing slot with include_overlap: false" do
       # Wednesday 2019-01-16 10:30 is within 09:00-14:00, but we want the next one
       dt = build_dt(~N[2019-01-16 10:30:00])
 
-      assert TimeSlot.next(@schedule, dt, inclusive: false) == [
+      assert TimeSlot.next(@schedule, dt, include_overlap: false) == [
                %TimeSlot{
                  starts_at: build_dt(~N[2019-01-16 15:00:00]),
                  ends_at: build_dt(~N[2019-01-16 17:00:00])
@@ -197,10 +197,10 @@ defmodule OpenHours.TimeSlotTest do
              ]
     end
 
-    test "inclusive: false has no effect when outside business hours" do
+    test "include_overlap: false has no effect when outside business hours" do
       dt = build_dt(~N[2019-01-16 14:30:00])
 
-      assert TimeSlot.next(@schedule, dt, inclusive: false) ==
+      assert TimeSlot.next(@schedule, dt, include_overlap: false) ==
                TimeSlot.next(@schedule, dt)
     end
 
@@ -293,10 +293,10 @@ defmodule OpenHours.TimeSlotTest do
              ]
     end
 
-    test "excludes containing slot with inclusive: false" do
+    test "excludes containing slot with include_overlap: false" do
       dt = build_dt(~N[2019-01-16 10:30:00])
 
-      assert TimeSlot.previous(@schedule, dt, inclusive: false) == [
+      assert TimeSlot.previous(@schedule, dt, include_overlap: false) == [
                %TimeSlot{
                  starts_at: build_dt(~N[2019-01-14 15:00:00]),
                  ends_at: build_dt(~N[2019-01-14 20:00:00])
@@ -304,10 +304,10 @@ defmodule OpenHours.TimeSlotTest do
              ]
     end
 
-    test "inclusive: false has no effect when outside business hours" do
+    test "include_overlap: false has no effect when outside business hours" do
       dt = build_dt(~N[2019-01-16 14:30:00])
 
-      assert TimeSlot.previous(@schedule, dt, inclusive: false) ==
+      assert TimeSlot.previous(@schedule, dt, include_overlap: false) ==
                TimeSlot.previous(@schedule, dt)
     end
 


### PR DESCRIPTION
## Summary
- Add `TimeSlot.next/3` to find the next time slot(s) from a given DateTime, looking forward through the schedule
- Add `TimeSlot.previous/3` to find the previous time slot(s), looking backward
- Both support `:limit` (number of slots) and `:include_overlap` (include containing slot) options
- Refactor internal `time_slots_for` into shared `time_slots_for_day/2` helper

## Test plan
- [x] Containing slot returned when datetime is within business hours
- [x] Next/previous slot returned when outside business hours
- [x] Crosses day boundaries correctly
- [x] Skips holidays, weekends
- [x] Respects shifts and breaks
- [x] `limit` option returns multiple slots
- [x] `include_overlap: false` excludes the containing slot
- [x] Empty schedule returns empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)