### PR TITLE
feat: add Offset.shift/3 for business time arithmetic

### DIFF
--- a/lib/open_hours/offset.ex
+++ b/lib/open_hours/offset.ex
@@ -1,0 +1,111 @@
+defmodule OpenHours.Offset do
+  @moduledoc """
+  This module provides business time arithmetic operations.
+
+  It allows shifting a DateTime forward or backward by a given amount of
+  business time, skipping over non-working hours, weekends, holidays, and breaks.
+  """
+
+  alias OpenHours.{Schedule, TimeSlot}
+
+  @duration_units [:hour, :minute]
+
+  @type duration :: {integer(), :hour | :minute}
+
+  @doc """
+  Shifts a DateTime forward or backward by the given amount of business time.
+
+  A positive amount shifts forward, a negative amount shifts backward.
+  When the starting DateTime is outside business hours, it snaps to the next
+  (forward) or previous (backward) business moment before applying the offset.
+
+  ## Examples
+
+      iex> schedule = %OpenHours.Schedule{
+      ...>   hours: %{
+      ...>     mon: [{~T[09:00:00], ~T[17:00:00]}],
+      ...>     tue: [{~T[09:00:00], ~T[17:00:00]}]
+      ...>   },
+      ...>   time_zone: "Europe/Madrid"
+      ...> }
+      iex> dt = DateTime.from_naive!(~N[2019-01-14 10:00:00], "Europe/Madrid", Tzdata.TimeZoneDatabase)
+      iex> OpenHours.Offset.shift(schedule, dt, {2, :hour})
+      DateTime.from_naive!(~N[2019-01-14 12:00:00], "Europe/Madrid", Tzdata.TimeZoneDatabase)
+
+  """
+  @spec shift(Schedule.t(), DateTime.t(), duration()) :: DateTime.t()
+  def shift(
+        %Schedule{time_zone: schedule_tz} = schedule,
+        %DateTime{time_zone: dt_tz} = dt,
+        duration
+      )
+      when schedule_tz != dt_tz do
+    {:ok, shifted} = DateTime.shift_zone(dt, schedule_tz, Tzdata.TimeZoneDatabase)
+    shift(schedule, shifted, duration)
+  end
+
+  def shift(%Schedule{} = schedule, %DateTime{} = dt, {amount, unit})
+      when amount > 0 and unit in @duration_units do
+    shift_forward(schedule, dt, to_seconds(amount, unit))
+  end
+
+  def shift(%Schedule{} = schedule, %DateTime{} = dt, {amount, unit})
+      when amount < 0 and unit in @duration_units do
+    shift_backward(schedule, dt, to_seconds(abs(amount), unit))
+  end
+
+  def shift(%Schedule{}, %DateTime{}, {0, unit}) when unit in @duration_units do
+    raise ArgumentError, "amount must be a non-zero integer, got: 0"
+  end
+
+  def shift(%Schedule{}, %DateTime{}, {_amount, unit}) when unit not in @duration_units do
+    raise ArgumentError, "unsupported unit #{inspect(unit)}, expected :hour or :minute"
+  end
+
+  defp shift_forward(schedule, dt, remaining_seconds) do
+    case TimeSlot.next(schedule, dt, limit: 1) do
+      [] -> raise ArgumentError, "no business hours available in the schedule"
+      [slot] -> shift_forward_slot(slot, schedule, dt, remaining_seconds)
+    end
+  end
+
+  defp shift_forward_slot(slot, schedule, dt, remaining_seconds) do
+    position = max_dt(dt, slot.starts_at)
+    available = DateTime.diff(slot.ends_at, position)
+
+    if available >= remaining_seconds do
+      DateTime.add(position, remaining_seconds, :second, Tzdata.TimeZoneDatabase)
+    else
+      shift_forward(schedule, slot.ends_at, remaining_seconds - available)
+    end
+  end
+
+  defp shift_backward(schedule, dt, remaining_seconds) do
+    case TimeSlot.previous(schedule, dt, limit: 1) do
+      [] -> raise ArgumentError, "no business hours available in the schedule"
+      [slot] -> shift_backward_slot(slot, schedule, dt, remaining_seconds)
+    end
+  end
+
+  defp shift_backward_slot(slot, schedule, dt, remaining_seconds) do
+    position = min_dt(dt, slot.ends_at)
+    available = DateTime.diff(position, slot.starts_at)
+
+    if available >= remaining_seconds do
+      DateTime.add(position, -remaining_seconds, :second, Tzdata.TimeZoneDatabase)
+    else
+      shift_backward(schedule, slot.starts_at, remaining_seconds - available)
+    end
+  end
+
+  defp to_seconds(amount, :hour), do: amount * 3600
+  defp to_seconds(amount, :minute), do: amount * 60
+
+  defp max_dt(a, b) do
+    if DateTime.compare(a, b) == :gt, do: a, else: b
+  end
+
+  defp min_dt(a, b) do
+    if DateTime.compare(a, b) == :lt, do: a, else: b
+  end
+end

--- a/test/open_hours/offset_test.exs
+++ b/test/open_hours/offset_test.exs
@@ -1,0 +1,196 @@
+defmodule OpenHours.OffsetTest do
+  use ExUnit.Case
+
+  alias OpenHours.{Offset, Schedule}
+
+  # Week of 2019-01-14 (Monday):
+  # Mon-Fri: 09:00-14:00, 15:00-20:00 (10h/day)
+  # Tuesday 2019-01-15: holiday
+  # Wednesday 2019-01-16: break 17:00-20:00 (second slot becomes 15:00-17:00, 7h total)
+  # Friday 2019-01-18: shift 10:00-14:00 (4h total)
+  @schedule %Schedule{
+    hours: %{
+      mon: [{~T[09:00:00], ~T[14:00:00]}, {~T[15:00:00], ~T[20:00:00]}],
+      tue: [{~T[09:00:00], ~T[14:00:00]}, {~T[15:00:00], ~T[20:00:00]}],
+      wed: [{~T[09:00:00], ~T[14:00:00]}, {~T[15:00:00], ~T[20:00:00]}],
+      thu: [{~T[09:00:00], ~T[14:00:00]}, {~T[15:00:00], ~T[20:00:00]}],
+      fri: [{~T[09:00:00], ~T[14:00:00]}, {~T[15:00:00], ~T[20:00:00]}]
+    },
+    holidays: [~D[2019-01-15]],
+    shifts: [{~D[2019-01-18], [{~T[10:00:00], ~T[14:00:00]}]}],
+    breaks: [{~D[2019-01-16], [{~T[17:00:00], ~T[20:00:00]}]}],
+    time_zone: "Europe/Madrid"
+  }
+
+  describe "shift/3 forward" do
+    test "within the same slot" do
+      # Wed 10:00 + 2h = Wed 12:00 (within 09:00-14:00)
+      dt = build_dt(~N[2019-01-16 10:00:00])
+      assert Offset.shift(@schedule, dt, {2, :hour}) == build_dt(~N[2019-01-16 12:00:00])
+    end
+
+    test "spans across slots in the same day" do
+      # Wed 13:00 + 3h: 1h left in 09-14, gap, 2h into 15-17 = Wed 17:00
+      dt = build_dt(~N[2019-01-16 13:00:00])
+      assert Offset.shift(@schedule, dt, {3, :hour}) == build_dt(~N[2019-01-16 17:00:00])
+    end
+
+    test "spans across days" do
+      # Wed 16:00 + 3h: 1h left in 15-17, then Thu 09-14: 2h in = Thu 11:00
+      dt = build_dt(~N[2019-01-16 16:00:00])
+      assert Offset.shift(@schedule, dt, {3, :hour}) == build_dt(~N[2019-01-17 11:00:00])
+    end
+
+    test "snaps to next business moment when starting outside hours" do
+      # Wed 14:30 + 2h: snaps to 15:00, then 2h into 15-17 = Wed 17:00
+      dt = build_dt(~N[2019-01-16 14:30:00])
+      assert Offset.shift(@schedule, dt, {2, :hour}) == build_dt(~N[2019-01-16 17:00:00])
+    end
+
+    test "skips holidays" do
+      # Mon 19:00 + 2h: 1h left in Mon 15-20, Tue is holiday, 1h into Wed 09-14 = Wed 10:00
+      dt = build_dt(~N[2019-01-14 19:00:00])
+      assert Offset.shift(@schedule, dt, {2, :hour}) == build_dt(~N[2019-01-16 10:00:00])
+    end
+
+    test "respects shifts" do
+      # Fri 11:00 + 2h: within shift 10-14, result = Fri 13:00
+      dt = build_dt(~N[2019-01-18 11:00:00])
+      assert Offset.shift(@schedule, dt, {2, :hour}) == build_dt(~N[2019-01-18 13:00:00])
+    end
+
+    test "respects breaks" do
+      # Wed 16:30 + 1h: only 30min left in 15-17 (break cuts 17-20), 30min into Thu 09-14 = Thu 09:30
+      dt = build_dt(~N[2019-01-16 16:30:00])
+      assert Offset.shift(@schedule, dt, {1, :hour}) == build_dt(~N[2019-01-17 09:30:00])
+    end
+
+    test "skips weekends" do
+      # Fri 13:00 + 3h: 1h left in shift 10-14, no Sat/Sun, Mon 09 + 2h = Mon 11:00
+      dt = build_dt(~N[2019-01-18 13:00:00])
+      assert Offset.shift(@schedule, dt, {3, :hour}) == build_dt(~N[2019-01-21 11:00:00])
+    end
+
+    test "with minutes unit" do
+      # Wed 13:45 + 30min: 15min left in 09-14, gap, 15min into 15-17 = Wed 15:15
+      dt = build_dt(~N[2019-01-16 13:45:00])
+      assert Offset.shift(@schedule, dt, {30, :minute}) == build_dt(~N[2019-01-16 15:15:00])
+    end
+  end
+
+  describe "shift/3 backward" do
+    test "within the same slot" do
+      # Wed 12:00 - 2h = Wed 10:00 (within 09:00-14:00)
+      dt = build_dt(~N[2019-01-16 12:00:00])
+      assert Offset.shift(@schedule, dt, {-2, :hour}) == build_dt(~N[2019-01-16 10:00:00])
+    end
+
+    test "spans across slots in the same day" do
+      # Wed 16:00 - 3h: 1h back in 15-17 (to 15:00), gap, 2h back in 09-14 (from 14:00) = Wed 12:00
+      dt = build_dt(~N[2019-01-16 16:00:00])
+      assert Offset.shift(@schedule, dt, {-3, :hour}) == build_dt(~N[2019-01-16 12:00:00])
+    end
+
+    test "spans across days" do
+      # Thu 10:00 - 7h: 1h back in Thu 09-10, then Wed 15-17 (2h), then Wed 09-14: 4h from end = Wed 10:00
+      dt = build_dt(~N[2019-01-17 10:00:00])
+      assert Offset.shift(@schedule, dt, {-7, :hour}) == build_dt(~N[2019-01-16 10:00:00])
+    end
+
+    test "snaps to previous business moment when starting outside hours" do
+      # Wed 14:30 - 2h: snaps to 14:00, then 2h back in 09-14 = Wed 12:00
+      dt = build_dt(~N[2019-01-16 14:30:00])
+      assert Offset.shift(@schedule, dt, {-2, :hour}) == build_dt(~N[2019-01-16 12:00:00])
+    end
+
+    test "skips holidays" do
+      # Wed 10:00 - 2h: 1h back in Wed 09-10, Tue is holiday, 1h back in Mon 15-20 (from 20:00) = Mon 19:00
+      dt = build_dt(~N[2019-01-16 10:00:00])
+      assert Offset.shift(@schedule, dt, {-2, :hour}) == build_dt(~N[2019-01-14 19:00:00])
+    end
+
+    test "skips weekends" do
+      # Mon 2019-01-21 10:00 - 3h: 1h back Mon 09-10, no Sat/Sun, Fri has shift 10-14 (4h),
+      # 2h from end = Fri 12:00
+      dt = build_dt(~N[2019-01-21 10:00:00])
+      assert Offset.shift(@schedule, dt, {-3, :hour}) == build_dt(~N[2019-01-18 12:00:00])
+    end
+
+    test "with minutes unit" do
+      # Wed 15:15 - 30min: 15min back in 15-17 (to 15:00), gap, 15min back in 09-14 = Wed 13:45
+      dt = build_dt(~N[2019-01-16 15:15:00])
+      assert Offset.shift(@schedule, dt, {-30, :minute}) == build_dt(~N[2019-01-16 13:45:00])
+    end
+  end
+
+  describe "shift/3 with different timezone" do
+    test "converts datetime to schedule timezone before calculating" do
+      # Wed 09:00 UTC = Wed 10:00 Europe/Madrid (CET = UTC+1)
+      # 10:00 Madrid + 2h = 12:00 Madrid
+      dt = DateTime.from_naive!(~N[2019-01-16 09:00:00], "Etc/UTC")
+      result = Offset.shift(@schedule, dt, {2, :hour})
+      assert result == build_dt(~N[2019-01-16 12:00:00])
+    end
+  end
+
+  describe "shift/3 edge cases" do
+    test "starting exactly at slot boundary (start)" do
+      # Wed 09:00 + 1h = Wed 10:00
+      dt = build_dt(~N[2019-01-16 09:00:00])
+      assert Offset.shift(@schedule, dt, {1, :hour}) == build_dt(~N[2019-01-16 10:00:00])
+    end
+
+    test "starting exactly at slot boundary (end)" do
+      # Wed 14:00 + 1h: at boundary of 09-14, snaps forward to 15:00, then 1h = 16:00
+      dt = build_dt(~N[2019-01-16 14:00:00])
+      assert Offset.shift(@schedule, dt, {1, :hour}) == build_dt(~N[2019-01-16 16:00:00])
+    end
+
+    test "duration exactly consumes a full slot" do
+      # Wed 15:00 + 2h = Wed 17:00 (exactly consumes 15:00-17:00 due to break)
+      dt = build_dt(~N[2019-01-16 15:00:00])
+      assert Offset.shift(@schedule, dt, {2, :hour}) == build_dt(~N[2019-01-16 17:00:00])
+    end
+
+    test "large duration spanning multiple days" do
+      # Mon 09:00 + 20h:
+      # Mon: 09-14 (5h) + 15-20 (5h) = 10h. Remaining: 10h
+      # Tue: holiday. Remaining: 10h
+      # Wed: 09-14 (5h) + 15-17 (2h) = 7h. Remaining: 3h
+      # Thu: 09-14, 3h in = Thu 12:00
+      dt = build_dt(~N[2019-01-14 09:00:00])
+      assert Offset.shift(@schedule, dt, {20, :hour}) == build_dt(~N[2019-01-17 12:00:00])
+    end
+  end
+
+  describe "shift/3 error handling" do
+    test "raises on unsupported unit" do
+      dt = build_dt(~N[2019-01-16 10:00:00])
+
+      assert_raise ArgumentError, "unsupported unit :day, expected :hour or :minute", fn ->
+        Offset.shift(@schedule, dt, {1, :day})
+      end
+    end
+
+    test "raises on zero amount" do
+      dt = build_dt(~N[2019-01-16 10:00:00])
+
+      assert_raise ArgumentError, "amount must be a non-zero integer, got: 0", fn ->
+        Offset.shift(@schedule, dt, {0, :hour})
+      end
+    end
+
+    test "raises on empty schedule" do
+      empty = %Schedule{time_zone: "Europe/Madrid"}
+      dt = build_dt(~N[2019-01-16 10:00:00])
+
+      assert_raise ArgumentError, "no business hours available in the schedule", fn ->
+        Offset.shift(empty, dt, {1, :hour})
+      end
+    end
+  end
+
+  defp build_dt(naive_datetime) do
+    DateTime.from_naive!(naive_datetime, "Europe/Madrid", Tzdata.TimeZoneDatabase)
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `OpenHours.Offset.shift/3` to shift a DateTime forward or backward by business time
- Supports `:hour` and `:minute` duration units with positive (forward) or negative (backward) amounts
- Automatically snaps to next/previous business moment when starting outside business hours
- Raises clear `ArgumentError` for unsupported units, zero amounts, or empty schedules

## Test plan
- [x] Forward shift: within slot, across slots, across days
- [x] Backward shift: within slot, across slots, across days
- [x] Holidays, shifts, breaks, and weekends are respected
- [x] Timezone conversion when datetime differs from schedule
- [x] Edge cases: slot boundaries, large durations, minutes unit
- [x] Error handling: unsupported unit, zero amount, empty schedule
- [x] Full test suite passes (73 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)