### PR TITLE
feat: add stream_next/3 and stream_previous/3 to TimeSlot

### DIFF
--- a/lib/open_hours/time_slot.ex
+++ b/lib/open_hours/time_slot.ex
@@ -59,32 +59,11 @@ defmodule OpenHours.TimeSlot do
   Returns a list of `%TimeSlot{}` structs ordered chronologically.
   """
   @spec next(Schedule.t(), DateTime.t(), keyword()) :: [t()]
-  def next(schedule, at, opts \\ [])
-
-  def next(%Schedule{time_zone: schedule_tz} = schedule, %DateTime{time_zone: dt_tz} = at, opts)
-      when schedule_tz != dt_tz do
-    {:ok, shifted} = DateTime.shift_zone(at, schedule_tz, Tzdata.TimeZoneDatabase)
-    next(schedule, shifted, opts)
-  end
-
-  def next(%Schedule{} = schedule, %DateTime{} = _at, _opts)
-      when schedule.hours == %{} and schedule.shifts == [] do
-    []
-  end
-
-  def next(%Schedule{} = schedule, %DateTime{} = at, opts) do
+  def next(schedule, at, opts \\ []) do
     limit = Keyword.get(opts, :limit, 1)
-    include_overlap = Keyword.get(opts, :include_overlap, true)
 
     schedule
-    |> stream_forward(DateTime.to_date(at))
-    |> Stream.filter(fn slot ->
-      if include_overlap do
-        DateTime.compare(slot.ends_at, at) == :gt
-      else
-        DateTime.compare(slot.starts_at, at) == :gt
-      end
-    end)
+    |> stream_next(at, Keyword.take(opts, [:include_overlap]))
     |> Enum.take(limit)
   end
 
@@ -100,25 +79,101 @@ defmodule OpenHours.TimeSlot do
   Returns a list of `%TimeSlot{}` structs ordered from most recent to least recent.
   """
   @spec previous(Schedule.t(), DateTime.t(), keyword()) :: [t()]
-  def previous(schedule, at, opts \\ [])
+  def previous(schedule, at, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 1)
 
-  def previous(%Schedule{time_zone: schedule_tz} = schedule, %DateTime{time_zone: dt_tz} = at, opts)
-      when schedule_tz != dt_tz do
-    {:ok, shifted} = DateTime.shift_zone(at, schedule_tz, Tzdata.TimeZoneDatabase)
-    previous(schedule, shifted, opts)
+    schedule
+    |> stream_previous(at, Keyword.take(opts, [:include_overlap]))
+    |> Enum.take(limit)
   end
 
-  def previous(%Schedule{} = schedule, %DateTime{} = _at, _opts)
+  @doc """
+  Returns a lazy stream of time slots from the given DateTime, looking forward
+  in the schedule.
+
+  The stream is infinite and respects holidays, shifts, and breaks.
+
+  ## Options
+
+    * `:include_overlap` - if `true`, includes the slot containing the given
+      DateTime (default: `true`)
+
+  ## Examples
+
+      schedule
+      |> TimeSlot.stream_next(datetime)
+      |> Enum.take(5)
+
+  """
+  @spec stream_next(Schedule.t(), DateTime.t(), keyword()) :: Enumerable.t()
+  def stream_next(schedule, at, opts \\ [])
+
+  def stream_next(%Schedule{time_zone: schedule_tz} = schedule, %DateTime{time_zone: dt_tz} = at, opts)
+      when schedule_tz != dt_tz do
+    {:ok, shifted} = DateTime.shift_zone(at, schedule_tz, Tzdata.TimeZoneDatabase)
+    stream_next(schedule, shifted, opts)
+  end
+
+  def stream_next(%Schedule{} = schedule, %DateTime{} = _at, _opts)
       when schedule.hours == %{} and schedule.shifts == [] do
     []
   end
 
-  def previous(%Schedule{} = schedule, %DateTime{} = at, opts) do
-    limit = Keyword.get(opts, :limit, 1)
+  def stream_next(%Schedule{} = schedule, %DateTime{} = at, opts) do
     include_overlap = Keyword.get(opts, :include_overlap, true)
 
     schedule
-    |> stream_backward(DateTime.to_date(at))
+    |> dates_forward(DateTime.to_date(at))
+    |> Stream.reject(&Enum.member?(schedule.holidays, &1))
+    |> Stream.flat_map(&time_slots_for_day(schedule, &1))
+    |> Stream.filter(fn slot ->
+      if include_overlap do
+        DateTime.compare(slot.ends_at, at) == :gt
+      else
+        DateTime.compare(slot.starts_at, at) == :gt
+      end
+    end)
+  end
+
+  @doc """
+  Returns a lazy stream of time slots from the given DateTime, looking backward
+  in the schedule.
+
+  The stream is infinite and respects holidays, shifts, and breaks.
+
+  ## Options
+
+    * `:include_overlap` - if `true`, includes the slot containing the given
+      DateTime (default: `true`)
+
+  ## Examples
+
+      schedule
+      |> TimeSlot.stream_previous(datetime)
+      |> Enum.take(5)
+
+  """
+  @spec stream_previous(Schedule.t(), DateTime.t(), keyword()) :: Enumerable.t()
+  def stream_previous(schedule, at, opts \\ [])
+
+  def stream_previous(%Schedule{time_zone: schedule_tz} = schedule, %DateTime{time_zone: dt_tz} = at, opts)
+      when schedule_tz != dt_tz do
+    {:ok, shifted} = DateTime.shift_zone(at, schedule_tz, Tzdata.TimeZoneDatabase)
+    stream_previous(schedule, shifted, opts)
+  end
+
+  def stream_previous(%Schedule{} = schedule, %DateTime{} = _at, _opts)
+      when schedule.hours == %{} and schedule.shifts == [] do
+    []
+  end
+
+  def stream_previous(%Schedule{} = schedule, %DateTime{} = at, opts) do
+    include_overlap = Keyword.get(opts, :include_overlap, true)
+
+    schedule
+    |> dates_backward(DateTime.to_date(at))
+    |> Stream.reject(&Enum.member?(schedule.holidays, &1))
+    |> Stream.flat_map(&(schedule |> time_slots_for_day(&1) |> Enum.reverse()))
     |> Stream.filter(fn slot ->
       if include_overlap do
         DateTime.compare(slot.starts_at, at) == :lt
@@ -126,21 +181,28 @@ defmodule OpenHours.TimeSlot do
         DateTime.compare(slot.ends_at, at) == :lt
       end
     end)
-    |> Enum.take(limit)
   end
 
-  defp stream_forward(%Schedule{} = schedule, %Date{} = from) do
-    from
-    |> Stream.iterate(&Date.add(&1, 1))
-    |> Stream.reject(&Enum.member?(schedule.holidays, &1))
-    |> Stream.flat_map(&time_slots_for_day(schedule, &1))
+  defp dates_forward(%Schedule{hours: hours, shifts: shifts}, %Date{} = from) when hours == %{} do
+    shifts
+    |> Enum.map(fn {date, _} -> date end)
+    |> Enum.sort(Date)
+    |> Enum.filter(&(Date.compare(&1, from) != :lt))
   end
 
-  defp stream_backward(%Schedule{} = schedule, %Date{} = from) do
-    from
-    |> Stream.iterate(&Date.add(&1, -1))
-    |> Stream.reject(&Enum.member?(schedule.holidays, &1))
-    |> Stream.flat_map(&(schedule |> time_slots_for_day(&1) |> Enum.reverse()))
+  defp dates_forward(_schedule, %Date{} = from) do
+    Stream.iterate(from, &Date.add(&1, 1))
+  end
+
+  defp dates_backward(%Schedule{hours: hours, shifts: shifts}, %Date{} = from) when hours == %{} do
+    shifts
+    |> Enum.map(fn {date, _} -> date end)
+    |> Enum.sort({:desc, Date})
+    |> Enum.filter(&(Date.compare(&1, from) != :gt))
+  end
+
+  defp dates_backward(_schedule, %Date{} = from) do
+    Stream.iterate(from, &Date.add(&1, -1))
   end
 
   defp time_slots_for_day(%Schedule{} = schedule, %Date{} = day) do

--- a/test/open_hours/time_slot_test.exs
+++ b/test/open_hours/time_slot_test.exs
@@ -319,6 +319,242 @@ defmodule OpenHours.TimeSlotTest do
     end
   end
 
+  describe "stream_next/3" do
+    test "returns a lazy stream of time slots" do
+      dt = build_dt(~N[2019-01-16 00:00:00])
+      slots = @schedule |> TimeSlot.stream_next(dt) |> Enum.take(3)
+
+      assert slots == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 14:00:00])
+               },
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 17:00:00])
+               },
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-17 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-17 14:00:00])
+               }
+             ]
+    end
+
+    test "includes overlapping slot by default" do
+      # Wed 10:30 is within 09:00-14:00, should include that slot
+      dt = build_dt(~N[2019-01-16 10:30:00])
+      slots = @schedule |> TimeSlot.stream_next(dt) |> Enum.take(1)
+
+      assert slots == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 14:00:00])
+               }
+             ]
+    end
+
+    test "excludes overlapping slot with include_overlap: false" do
+      # Wed 10:30 is within 09:00-14:00, skip it
+      dt = build_dt(~N[2019-01-16 10:30:00])
+      slots = @schedule |> TimeSlot.stream_next(dt, include_overlap: false) |> Enum.take(1)
+
+      assert slots == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 17:00:00])
+               }
+             ]
+    end
+
+    test "skips holidays" do
+      # Starting from Monday, Tuesday is a holiday
+      dt = build_dt(~N[2019-01-14 00:00:00])
+      slots = @schedule |> TimeSlot.stream_next(dt) |> Enum.take(3)
+
+      assert [first, second, _] = slots
+      assert DateTime.to_date(first.starts_at) == ~D[2019-01-14]
+      assert DateTime.to_date(second.starts_at) == ~D[2019-01-14]
+      # Third slot is Wednesday (skips Tuesday holiday)
+    end
+
+    test "skips weekends" do
+      # Starting from Friday (shift day), next slots are Monday
+      dt = build_dt(~N[2019-01-18 00:00:00])
+      slots = @schedule |> TimeSlot.stream_next(dt) |> Enum.take(2)
+
+      assert [friday, monday] = slots
+      assert DateTime.to_date(friday.starts_at) == ~D[2019-01-18]
+      assert DateTime.to_date(monday.starts_at) == ~D[2019-01-21]
+    end
+
+    test "respects shifts" do
+      # Friday 2019-01-18 has shift 10:00-14:00 (single slot instead of two)
+      dt = build_dt(~N[2019-01-18 00:00:00])
+      slots = @schedule |> TimeSlot.stream_next(dt) |> Enum.take(1)
+
+      assert slots == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-18 10:00:00]),
+                 ends_at: build_dt(~N[2019-01-18 14:00:00])
+               }
+             ]
+    end
+
+    test "respects breaks" do
+      # Wednesday 2019-01-16 has break 17:00-20:00
+      dt = build_dt(~N[2019-01-16 00:00:00])
+      slots = @schedule |> TimeSlot.stream_next(dt) |> Enum.take(2)
+
+      assert [_, second] = slots
+      assert second.ends_at == build_dt(~N[2019-01-16 17:00:00])
+    end
+
+    test "returns empty stream for empty schedule" do
+      empty = %Schedule{time_zone: "Europe/Madrid"}
+      dt = build_dt(~N[2019-01-16 10:00:00])
+      slots = empty |> TimeSlot.stream_next(dt) |> Enum.take(1)
+
+      assert slots == []
+    end
+
+    test "does not loop infinitely when hours are empty and shifts are in the past" do
+      schedule = %Schedule{
+        hours: %{},
+        shifts: [{~D[2019-01-15], [{~T[10:00:00], ~T[15:00:00]}]}],
+        time_zone: "Europe/Madrid"
+      }
+
+      dt = build_dt(~N[2019-01-16 10:00:00])
+      slots = schedule |> TimeSlot.stream_next(dt) |> Enum.take(1)
+
+      assert slots == []
+    end
+
+    test "returns shift slots when hours are empty and shift is ahead" do
+      schedule = %Schedule{
+        hours: %{},
+        shifts: [{~D[2019-01-18], [{~T[10:00:00], ~T[15:00:00]}]}],
+        time_zone: "Europe/Madrid"
+      }
+
+      dt = build_dt(~N[2019-01-16 10:00:00])
+      slots = schedule |> TimeSlot.stream_next(dt) |> Enum.take(1)
+
+      assert slots == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-18 10:00:00]),
+                 ends_at: build_dt(~N[2019-01-18 15:00:00])
+               }
+             ]
+    end
+  end
+
+  describe "stream_previous/3" do
+    test "returns a lazy stream of time slots in reverse" do
+      dt = build_dt(~N[2019-01-17 23:00:00])
+      slots = @schedule |> TimeSlot.stream_previous(dt) |> Enum.take(3)
+
+      assert slots == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-17 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-17 20:00:00])
+               },
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-17 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-17 14:00:00])
+               },
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 17:00:00])
+               }
+             ]
+    end
+
+    test "includes overlapping slot by default" do
+      # Thu 10:30 is within 09:00-14:00, should include that slot
+      dt = build_dt(~N[2019-01-17 10:30:00])
+      slots = @schedule |> TimeSlot.stream_previous(dt) |> Enum.take(1)
+
+      assert slots == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-17 09:00:00]),
+                 ends_at: build_dt(~N[2019-01-17 14:00:00])
+               }
+             ]
+    end
+
+    test "excludes overlapping slot with include_overlap: false" do
+      # Thu 10:30 is within 09:00-14:00, skip it
+      dt = build_dt(~N[2019-01-17 10:30:00])
+      slots = @schedule |> TimeSlot.stream_previous(dt, include_overlap: false) |> Enum.take(1)
+
+      assert slots == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-16 15:00:00]),
+                 ends_at: build_dt(~N[2019-01-16 17:00:00])
+               }
+             ]
+    end
+
+    test "skips holidays" do
+      # Starting from Wednesday backward, Tuesday is a holiday
+      dt = build_dt(~N[2019-01-16 23:00:00])
+      slots = @schedule |> TimeSlot.stream_previous(dt) |> Enum.take(4)
+
+      dates = Enum.map(slots, &DateTime.to_date(&1.starts_at))
+      # Should go Wed, Wed, then skip Tue to Mon, Mon
+      assert dates == [~D[2019-01-16], ~D[2019-01-16], ~D[2019-01-14], ~D[2019-01-14]]
+    end
+
+    test "skips weekends" do
+      # Starting from Monday backward, Mon has 2 slots, then skip Sat/Sun to Friday
+      dt = build_dt(~N[2019-01-21 23:00:00])
+      slots = @schedule |> TimeSlot.stream_previous(dt) |> Enum.take(3)
+
+      dates = Enum.map(slots, &DateTime.to_date(&1.starts_at))
+      assert dates == [~D[2019-01-21], ~D[2019-01-21], ~D[2019-01-18]]
+    end
+
+    test "returns empty stream for empty schedule" do
+      empty = %Schedule{time_zone: "Europe/Madrid"}
+      dt = build_dt(~N[2019-01-16 10:00:00])
+      slots = empty |> TimeSlot.stream_previous(dt) |> Enum.take(1)
+
+      assert slots == []
+    end
+
+    test "does not loop infinitely when hours are empty and shifts are in the future" do
+      schedule = %Schedule{
+        hours: %{},
+        shifts: [{~D[2019-01-18], [{~T[10:00:00], ~T[15:00:00]}]}],
+        time_zone: "Europe/Madrid"
+      }
+
+      dt = build_dt(~N[2019-01-16 10:00:00])
+      slots = schedule |> TimeSlot.stream_previous(dt) |> Enum.take(1)
+
+      assert slots == []
+    end
+
+    test "returns shift slots when hours are empty and shift is behind" do
+      schedule = %Schedule{
+        hours: %{},
+        shifts: [{~D[2019-01-15], [{~T[10:00:00], ~T[15:00:00]}]}],
+        time_zone: "Europe/Madrid"
+      }
+
+      dt = build_dt(~N[2019-01-16 10:00:00])
+      slots = schedule |> TimeSlot.stream_previous(dt) |> Enum.take(1)
+
+      assert slots == [
+               %TimeSlot{
+                 starts_at: build_dt(~N[2019-01-15 10:00:00]),
+                 ends_at: build_dt(~N[2019-01-15 15:00:00])
+               }
+             ]
+    end
+  end
+
   defp build_dt(naive_datetime) do
     DateTime.from_naive!(naive_datetime, "Europe/Madrid", Tzdata.TimeZoneDatabase)
   end


### PR DESCRIPTION
## Summary
- Add `TimeSlot.stream_next/3` and `TimeSlot.stream_previous/3` as public lazy stream functions for iterating through time slots forward and backward
- Both accept a `DateTime` and support the `:include_overlap` option, consistent with `next/3` and `previous/3`
- Refactor `next/3` and `previous/3` to delegate to the new stream functions with `Enum.take(limit)`
- Handle empty schedules by returning an empty list (avoids infinite iteration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)