### PR TITLE
feat: add :day unit to Offset.shift/3

### DIFF
--- a/lib/open_hours/offset.ex
+++ b/lib/open_hours/offset.ex
@@ -8,16 +8,74 @@ defmodule OpenHours.Offset do
 
   alias OpenHours.{Schedule, TimeSlot}
 
-  @duration_units [:hour, :minute]
+  @duration_units [:hour, :minute, :day]
 
-  @type duration :: {integer(), :hour | :minute}
+  @type duration :: {integer(), :hour | :minute | :day}
 
   @doc """
   Shifts a DateTime forward or backward by the given amount of business time.
 
   A positive amount shifts forward, a negative amount shifts backward.
-  When the starting DateTime is outside business hours, it snaps to the next
-  (forward) or previous (backward) business moment before applying the offset.
+  Supports `:hour`, `:minute`, and `:day` units.
+
+  ## Hour and minute shifts
+
+  For `:hour` and `:minute` units, the shift consumes the exact amount of
+  business time, walking through consecutive time slots and skipping
+  non-working periods. When the starting DateTime is outside business hours,
+  it snaps to the next (forward) or previous (backward) business moment
+  before applying the offset.
+
+  ## Day shifts
+
+  For the `:day` unit, the shift moves to the Nth business day forward or
+  backward, preserving the time of day when possible. A "business day" is
+  any day that has at least one time slot in the schedule (not a holiday,
+  and has configured hours or a shift override).
+
+  The current day is never counted — `{1, :day}` always moves to a
+  different date.
+
+  ### Time preservation and snapping
+
+  The algorithm tries to keep the original time of day on the target date.
+  When the time falls within business hours on the target day, it is
+  preserved exactly. When it does not, the result is the nearest business
+  moment in the direction of the shift — which may be on a different day
+  than the target:
+
+    * **Forward**: finds the next business moment after the target
+      date + time. If the time falls in a gap between slots on the
+      target day, this is the start of the next slot on that day. If
+      the time is past all slots on the target day, this is the start
+      of business on the next business day.
+    * **Backward**: finds the previous business moment before the
+      target date + time. If the time falls in a gap, this is the end
+      of the preceding slot. If the time is before all slots, this is
+      the end of business on the previous business day.
+
+  This matters when the target day has different hours than the origin day
+  (e.g. a shift override with shorter hours, or a day with breaks that
+  create gaps).
+
+  ### Examples
+
+  Given a schedule with Mon–Fri 09:00–14:00 and 15:00–20:00, and
+  Friday overridden with a shift of 10:00–14:00:
+
+      # Time preserved: 10:00 exists in both days' hours
+      shift(schedule, ~N[2019-01-16 10:00:00], {1, :day})
+      #=> Thursday 10:00
+
+      # 15:00 is past Friday's shift (10:00–14:00), no later slot on
+      # Friday, so it flows forward to the next business day
+      shift(schedule, ~N[2019-01-17 15:00:00], {1, :day})
+      #=> Monday 09:00
+
+      # 14:30 falls in the gap between 09–14 and 15–20, snaps to
+      # the start of the next slot on the same day
+      shift(schedule, ~N[2019-01-14 14:30:00], {1, :day})
+      #=> Wednesday 15:00
 
   ## Examples
 
@@ -44,6 +102,16 @@ defmodule OpenHours.Offset do
     shift(schedule, shifted, duration)
   end
 
+  def shift(%Schedule{} = schedule, %DateTime{} = dt, {amount, :day})
+      when amount > 0 do
+    shift_days_forward(schedule, dt, amount)
+  end
+
+  def shift(%Schedule{} = schedule, %DateTime{} = dt, {amount, :day})
+      when amount < 0 do
+    shift_days_backward(schedule, dt, abs(amount))
+  end
+
   def shift(%Schedule{} = schedule, %DateTime{} = dt, {amount, unit})
       when amount > 0 and unit in @duration_units do
     shift_forward(schedule, dt, to_seconds(amount, unit))
@@ -59,7 +127,7 @@ defmodule OpenHours.Offset do
   end
 
   def shift(%Schedule{}, %DateTime{}, {_amount, unit}) when unit not in @duration_units do
-    raise ArgumentError, "unsupported unit #{inspect(unit)}, expected :hour or :minute"
+    raise ArgumentError, "unsupported unit #{inspect(unit)}, expected :hour, :minute, or :day"
   end
 
   defp shift_forward(schedule, dt, remaining_seconds) do
@@ -107,5 +175,57 @@ defmodule OpenHours.Offset do
 
   defp min_dt(a, b) do
     if DateTime.compare(a, b) == :lt, do: a, else: b
+  end
+
+  defp shift_days_forward(schedule, dt, count) do
+    time = DateTime.to_time(dt)
+
+    target_date =
+      schedule
+      |> TimeSlot.stream_next(dt, include_overlap: false)
+      |> Stream.map(&DateTime.to_date(&1.starts_at))
+      |> Stream.dedup()
+      |> Stream.drop_while(&(Date.compare(&1, DateTime.to_date(dt)) == :eq))
+      |> Enum.at(count - 1)
+
+    snap_to_business_time(schedule, target_date, time, :forward)
+  end
+
+  defp shift_days_backward(schedule, dt, count) do
+    time = DateTime.to_time(dt)
+
+    target_date =
+      schedule
+      |> TimeSlot.stream_previous(dt, include_overlap: false)
+      |> Stream.map(&DateTime.to_date(&1.starts_at))
+      |> Stream.dedup()
+      |> Stream.drop_while(&(Date.compare(&1, DateTime.to_date(dt)) == :eq))
+      |> Enum.at(count - 1)
+
+    snap_to_business_time(schedule, target_date, time, :backward)
+  end
+
+  defp snap_to_business_time(schedule, date, time, direction) do
+    dt = DateTime.new!(date, time, schedule.time_zone, Tzdata.TimeZoneDatabase)
+
+    if Schedule.in_hours?(schedule, dt) do
+      dt
+    else
+      find_nearest_business_moment(schedule, dt, direction)
+    end
+  end
+
+  defp find_nearest_business_moment(schedule, dt, :forward) do
+    case TimeSlot.next(schedule, dt, limit: 1) do
+      [slot] -> max_dt(dt, slot.starts_at)
+      [] -> raise ArgumentError, "no business hours available in the schedule"
+    end
+  end
+
+  defp find_nearest_business_moment(schedule, dt, :backward) do
+    case TimeSlot.previous(schedule, dt, limit: 1) do
+      [slot] -> min_dt(dt, slot.ends_at)
+      [] -> raise ArgumentError, "no business hours available in the schedule"
+    end
   end
 end

--- a/test/open_hours/offset_test.exs
+++ b/test/open_hours/offset_test.exs
@@ -163,20 +163,150 @@ defmodule OpenHours.OffsetTest do
     end
   end
 
+  describe "shift/3 forward by days" do
+    test "simple next business day" do
+      # Wed 10:00 + 1 day = Thu 10:00
+      dt = build_dt(~N[2019-01-16 10:00:00])
+      assert Offset.shift(@schedule, dt, {1, :day}) == build_dt(~N[2019-01-17 10:00:00])
+    end
+
+    test "preserves time of day" do
+      # Wed 11:30 + 1 day = Thu 11:30
+      dt = build_dt(~N[2019-01-16 11:30:00])
+      assert Offset.shift(@schedule, dt, {1, :day}) == build_dt(~N[2019-01-17 11:30:00])
+    end
+
+    test "skips holidays" do
+      # Mon 10:00 + 1 day: Tue is holiday, skip to Wed 10:00
+      dt = build_dt(~N[2019-01-14 10:00:00])
+      assert Offset.shift(@schedule, dt, {1, :day}) == build_dt(~N[2019-01-16 10:00:00])
+    end
+
+    test "skips weekends" do
+      # Fri 10:00 + 1 day: skip Sat/Sun = Mon 10:00
+      dt = build_dt(~N[2019-01-18 10:00:00])
+      assert Offset.shift(@schedule, dt, {1, :day}) == build_dt(~N[2019-01-21 10:00:00])
+    end
+
+    test "multiple days" do
+      # Mon 10:00 + 3 days: skip Tue (holiday) → Wed(1), Thu(2), Fri(3) = Fri 10:00
+      # Fri has shift 10-14, so 10:00 is within shift hours
+      dt = build_dt(~N[2019-01-14 10:00:00])
+      assert Offset.shift(@schedule, dt, {3, :day}) == build_dt(~N[2019-01-18 10:00:00])
+    end
+
+    test "moves to next business day when time is past all slots on target day" do
+      # Thu 15:00 + 1 day = Fri, but Fri has shift 10-14 only.
+      # 15:00 is past all slots on Fri, flows forward to Mon 09:00
+      dt = build_dt(~N[2019-01-17 15:00:00])
+      assert Offset.shift(@schedule, dt, {1, :day}) == build_dt(~N[2019-01-21 09:00:00])
+    end
+
+    test "snaps to next slot when time falls between slots" do
+      # Mon 14:30 + 1 day: Tue is holiday, skip to Wed.
+      # Wed has slots 09-14, 15-17. 14:30 is between them, snap to 15:00
+      dt = build_dt(~N[2019-01-14 14:30:00])
+      assert Offset.shift(@schedule, dt, {1, :day}) == build_dt(~N[2019-01-16 15:00:00])
+    end
+
+    test "starting outside business hours flows to next business day" do
+      # Mon 22:00 + 1 day: target is Wed (skip Tue holiday).
+      # 22:00 is past all slots on Wed, flows forward to Thu 09:00
+      dt = build_dt(~N[2019-01-14 22:00:00])
+      assert Offset.shift(@schedule, dt, {1, :day}) == build_dt(~N[2019-01-17 09:00:00])
+    end
+
+    test "multiple days spanning weeks" do
+      # Thu 10:00 + 3 days: Fri(1, shift), skip weekend, Mon(2), Tue(3) = Tue 10:00
+      dt = build_dt(~N[2019-01-17 10:00:00])
+      assert Offset.shift(@schedule, dt, {3, :day}) == build_dt(~N[2019-01-22 10:00:00])
+    end
+  end
+
+  describe "shift/3 backward by days" do
+    test "simple previous business day" do
+      # Thu 10:00 - 1 day = Wed 10:00
+      dt = build_dt(~N[2019-01-17 10:00:00])
+      assert Offset.shift(@schedule, dt, {-1, :day}) == build_dt(~N[2019-01-16 10:00:00])
+    end
+
+    test "preserves time of day" do
+      # Thu 11:30 - 1 day = Wed 11:30
+      dt = build_dt(~N[2019-01-17 11:30:00])
+      assert Offset.shift(@schedule, dt, {-1, :day}) == build_dt(~N[2019-01-16 11:30:00])
+    end
+
+    test "skips holidays" do
+      # Wed 10:00 - 1 day: Tue is holiday, skip to Mon 10:00
+      dt = build_dt(~N[2019-01-16 10:00:00])
+      assert Offset.shift(@schedule, dt, {-1, :day}) == build_dt(~N[2019-01-14 10:00:00])
+    end
+
+    test "skips weekends" do
+      # Mon 10:00 - 1 day: skip Sun/Sat = Fri 10:00
+      # Fri Jan 18 has shift 10-14, 10:00 is within
+      dt = build_dt(~N[2019-01-21 10:00:00])
+      assert Offset.shift(@schedule, dt, {-1, :day}) == build_dt(~N[2019-01-18 10:00:00])
+    end
+
+    test "multiple days" do
+      # Fri 10:00 - 3 days: Thu(1), Wed(2), Mon(3, skip Tue holiday) = Mon 10:00
+      dt = build_dt(~N[2019-01-18 10:00:00])
+      assert Offset.shift(@schedule, dt, {-3, :day}) == build_dt(~N[2019-01-14 10:00:00])
+    end
+
+    test "snaps to end of business when time is outside target day hours" do
+      # Mon 19:00 - 1 day: previous business day is Fri (Jan 18, skip weekend).
+      # Fri has shift 10-14, 19:00 is outside, snap to end of business = Fri 14:00
+      dt = build_dt(~N[2019-01-21 19:00:00])
+      assert Offset.shift(@schedule, dt, {-1, :day}) == build_dt(~N[2019-01-18 14:00:00])
+    end
+
+    test "snaps to previous slot when time falls between slots" do
+      # Thu 14:30 - 1 day: Wed.
+      # Wed has slots 09-14, 15-17. 14:30 is between them, snap to 14:00
+      dt = build_dt(~N[2019-01-17 14:30:00])
+      assert Offset.shift(@schedule, dt, {-1, :day}) == build_dt(~N[2019-01-16 14:00:00])
+    end
+
+    test "starting outside business hours flows to previous business day" do
+      # Thu 06:00 - 1 day: target is Wed.
+      # 06:00 is before all slots on Wed, flows backward to Mon 20:00 (skip Tue holiday)
+      dt = build_dt(~N[2019-01-17 06:00:00])
+      assert Offset.shift(@schedule, dt, {-1, :day}) == build_dt(~N[2019-01-14 20:00:00])
+    end
+  end
+
   describe "shift/3 error handling" do
     test "raises on unsupported unit" do
       dt = build_dt(~N[2019-01-16 10:00:00])
 
-      assert_raise ArgumentError, "unsupported unit :day, expected :hour or :minute", fn ->
-        Offset.shift(@schedule, dt, {1, :day})
+      assert_raise ArgumentError, "unsupported unit :second, expected :hour, :minute, or :day", fn ->
+        Offset.shift(@schedule, dt, {1, :second})
       end
     end
 
-    test "raises on zero amount" do
+    test "raises on zero hour amount" do
       dt = build_dt(~N[2019-01-16 10:00:00])
 
       assert_raise ArgumentError, "amount must be a non-zero integer, got: 0", fn ->
         Offset.shift(@schedule, dt, {0, :hour})
+      end
+    end
+
+    test "raises on zero minute amount" do
+      dt = build_dt(~N[2019-01-16 10:00:00])
+
+      assert_raise ArgumentError, "amount must be a non-zero integer, got: 0", fn ->
+        Offset.shift(@schedule, dt, {0, :minute})
+      end
+    end
+
+    test "raises on zero day amount" do
+      dt = build_dt(~N[2019-01-16 10:00:00])
+
+      assert_raise ArgumentError, "amount must be a non-zero integer, got: 0", fn ->
+        Offset.shift(@schedule, dt, {0, :day})
       end
     end
 


### PR DESCRIPTION
## Summary
- Add `:day` unit support to `Offset.shift/3` for business day arithmetic (e.g. `{3, :day}` for "3 business days from now")
- Preserves time of day on the target business day when possible; snaps to nearest business moment when the time doesn't fit (matching zendesk/biz behavior)
- Uses `TimeSlot.stream_next/3` and `stream_previous/3` to count business days, keeping Offset's dependencies minimal (`Schedule` + `TimeSlot` only)
- 17 new tests covering forward/backward shifts, holidays, weekends, multi-day spans, and snapping edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)