### PR TITLE
ci: fix elixir 1.18 / erlang 27.1 test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: 
+        include:
           - pair:
               elixir: "1.16"
               otp: "26.2"
               lint: lint
           - pair:
               elixir: "1.18"
-              otp: "27.1"
+              otp: "27.3"
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Fixes broken CI / Test run which was failing due to a "Unsupported Certificate" error.

For the pair of Elixir 1.18 and Erlang 27 it bumps the patch version to 27.3 of the latter.